### PR TITLE
Fix Zinc ore

### DIFF
--- a/scripts/mining_ore.lua
+++ b/scripts/mining_ore.lua
@@ -154,6 +154,9 @@ function getPoints()
   elseif (dropdown_ore_cur_value == 13) then
   ore = "Tungsten";
   stonecount = 12;
+  elseif (dropdown_ore_cur_value == 14) then
+  ore = "Zinc";
+  stonecount = 10;
   end
 
   local nodeleft = stonecount;


### PR DESCRIPTION
Zinc was included in the Pulldown menu, but it was missing a statement
to actually support it.