### PR TITLE
Update kettle_full.lua

### DIFF
--- a/scripts/kettle_full.lua
+++ b/scripts/kettle_full.lua
@@ -157,6 +157,8 @@ function igniteAll()
     lsSleep(50);
   end
   if #ignite > 0 then
+    --The lag is causing the refresh to not show "stoke max". Need a bit of a pause.
+    sleepWithStatus(2000, "Waiting for refresh");
     refreshAll();
   end
 end


### PR DESCRIPTION
Added a wait between igniting and refreshing as the lag was causing windows not to refresh w/ "stoke max" which could cause kettles to die out.